### PR TITLE
Added clip through first octant of cube in default VisIt output

### DIFF
--- a/PythonTool/DataLoading.py
+++ b/PythonTool/DataLoading.py
@@ -109,7 +109,11 @@ def plane_slice_plotting(window_number, axis_number, label, images):
     Vi.CopyPlotsToWindow(1, window_number)
 
     # Create the plane slice plot by activating the mesh, pseudocolor, and contour plots.
+    Vi.SetActiveWindow(window_number)
     Vi.SetActivePlots((0,1,2))
+
+    # Remove the clip and slice operators from previous windows.
+    Vi.RemoveAllOperators()
 
     # Add a slice through the proper axis.
     Vi.AddOperator("Slice", 1)
@@ -182,6 +186,10 @@ def data_loading(geometry_file, data_file, images, session_file):
        Vi.OpenDatabase(file["file_name"])
        Vi.AddPlot(file["plot_type"],file["data_tag"])
 
+   # Hide the contour plot in the first plot window.
+   Vi.SetActivePlots(2)
+   Vi.HideActivePlots()
+
    # Create the first plot of the cube by activating the mesh and pseudocolor plots.
    Vi.SetActivePlots((0,1))
 
@@ -189,6 +197,13 @@ def data_loading(geometry_file, data_file, images, session_file):
    v = Vi.GetView3D()
    v.viewNormal = (1,1,1)
    Vi.SetView3D(v)
+
+   # Apply a clip through the first octant of the cube.
+   Vi.AddOperator("Clip")
+   c = Vi.ClipAttributes()
+   c.plane1Origin = (40,40,40)
+   c.plane1Normal = (1,1,1)
+   Vi.SetOperatorOptions(c)
 
    # Include the CNERG logo in the bottom left corner of the plot.
    image = Vi.CreateAnnotationObject("Image")

--- a/PythonTool/DataLoading.py
+++ b/PythonTool/DataLoading.py
@@ -104,7 +104,7 @@ def plane_slice_plotting(window_number, axis_number, label, images):
       none
     """
 
-    # Open a new window with all three plots active.
+    # Open a new window with all three plots.
     Vi.AddWindow()
     Vi.CopyPlotsToWindow(1, window_number)
 
@@ -112,7 +112,7 @@ def plane_slice_plotting(window_number, axis_number, label, images):
     Vi.SetActiveWindow(window_number)
     Vi.SetActivePlots((0,1,2))
 
-    # Remove the clip and slice operators from previous windows.
+    # Remove the clip and slice operators from previous plot windows.
     Vi.RemoveAllOperators()
 
     # Add a slice through the proper axis.
@@ -121,7 +121,7 @@ def plane_slice_plotting(window_number, axis_number, label, images):
     s.axisType = axis_number
     Vi.SetOperatorOptions(s)
 
-    # Include label for each plane slice plot.
+    # Include a label for each plane slice plot.
     banner = Vi.CreateAnnotationObject("Text2D")
     banner.position = (0.45, 0.92)
     banner.text = label
@@ -190,7 +190,7 @@ def data_loading(geometry_file, data_file, images, session_file):
    Vi.SetActivePlots(2)
    Vi.HideActivePlots()
 
-   # Create the first plot of the cube by activating the mesh and pseudocolor plots.
+   # Create the plot of the cube by activating the mesh and pseudocolor plots.
    Vi.SetActivePlots((0,1))
 
    # Set the view normal to the first octant.
@@ -198,7 +198,7 @@ def data_loading(geometry_file, data_file, images, session_file):
    v.viewNormal = (1,1,1)
    Vi.SetView3D(v)
 
-   # Apply a clip through the first octant of the cube.
+   # Apply a clip through the first octant.
    Vi.AddOperator("Clip")
    c = Vi.ClipAttributes()
    c.plane1Origin = (40,40,40)

--- a/README.md
+++ b/README.md
@@ -36,7 +36,13 @@ A sample output from an h5m geometry file and a vtk data file can be seen below.
 
 ----------------------------------------
 
-2. GraveIdentifyAndRemove.py can be used to remove the graveyard volume/group from an h5m geometry file. The user may specify a specific output file name and extension. It can also extract curve, surface, and volume EntitySets.
+2. GraveIdentifyAndRemove.py can be used to remove the graveyard volume/group from an h5m geometry file. The new file will be written in the current directory with ```_no_grave.h5m``` appended onto the original file name. It can also extract curve, surface, and volume EntitySets.
+
+```
+python GraveIdentifyAndRemove.py [h5m file] 
+```
+
+The user may specify a specific output file name and extension by adding the ```-o``` option to the command. The new file will be written in the current directory.
  
 ```
 python GraveIdentifyAndRemove.py [h5m file] -o [output file] 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ The Direct Accelerated Geometry Monte Carlo visualization toolkit requires Pytho
 1. DataLoading.py can be used to create a default output in VisIt from an h5m geometry file and an h5m or vtk data file. The following four interactive plot windows are displayed in a 2x2 grid.
 
       1. A cube with a clip through the first octant.
-      2. XY plane slice through the center.
-      3. XZ plane slice through the center.
-      4. ZY plane slice through the center.
+      2. XY plane slice through the centroid.
+      3. XZ plane slice through the centroid.
+      4. ZY plane slice through the centroid.
       
 Each window has a mesh plot with the "STL_mesh" variable, a Pseudocolor plot with the "TALLY_TAG" variable, and the second, third, and fourth windows have Contour plots with the "ERROR_TAG" variable. 
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Direct Accelerated Geometry Monte Carlo visualization toolkit requires Pytho
 
 1. DataLoading.py can be used to create a default output in VisIt from an h5m geometry file and an h5m or vtk data file. The following four interactive plot windows are displayed in a 2x2 grid.
 
-      1. A cube with the default view normal to a corner.
+      1. A cube with a clip through the first octant.
       2. XY plane slice through the center.
       3. XZ plane slice through the center.
       4. ZY plane slice through the center.
@@ -31,7 +31,7 @@ python DataLoading.py [geometry_file] [data_file] -s
 A sample output from an h5m geometry file and a vtk data file can be seen below.
 
 <p align="center">
-<img src="https://i.postimg.cc/7ZJMPNCB/Screenshot-from-2018-11-08-13-01-26.png" width="400" height="400"/>
+<img src="https://i.postimg.cc/FRxFpL3S/Screenshot-from-2018-11-14-18-39-16.png" width="400" height="400"/>
 </p>
 
 ----------------------------------------


### PR DESCRIPTION
Added clip through first octant of cube in first plot window generated by DataLoading.py. Ensured that the first plot window only had mesh and pseudocolor plots. Updated the documentation to reflect progress.