### PR TITLE
Raise exception if graveyard is not found

### DIFF
--- a/PythonTool/DataLoading.py
+++ b/PythonTool/DataLoading.py
@@ -170,8 +170,8 @@ def data_loading(geometry_file, data_file, images, session_file):
    # Remove the graveyard from the geometry file.
    try:
        geometry_file = remove_graveyard(geometry_file)
-   except Exception:
-       print("WARNING: The geometry file did not contain a graveyard.")
+   except LookupError, e:
+       print(e.message)
        pass
 
    # Convert the geometry file and data file to the proper format.

--- a/PythonTool/DataLoading.py
+++ b/PythonTool/DataLoading.py
@@ -2,7 +2,7 @@ import argparse
 import os
 import visit as Vi
 from GraveIdentifyAndRemove import remove_graveyard
-from pymoab import core, types, tag
+from pymoab import core, tag, types
 
 
 def parse_arguments():
@@ -144,9 +144,9 @@ def data_loading(geometry_file, data_file, images, session_file):
    Convert geometry file to stl, convert data file to vtk, load each file
    into VisIt, and create and load a session file containing the four plot windows.
        1) A cube with a slice through an octant in order to see the center.
-       2) XY plane slice through the center.
-       3) XZ plane slice through the center.
-       4) YZ plane slice through the center.
+       2) XY plane slice through the centroid.
+       3) XZ plane slice through the centroid.
+       4) YZ plane slice through the centroid.
    Each window has a mesh plot with the "STL_mesh" variable, a Pseudocolor plot
    with the "TALLY_TAG" variable, and the second, third, and fourth windows have
    Contour plots with the "ERROR_TAG" variable.
@@ -168,7 +168,10 @@ def data_loading(geometry_file, data_file, images, session_file):
    """
 
    # Remove the graveyard from the geometry file.
-   geometry_file = remove_graveyard(geometry_file)
+   try:
+       geometry_file = remove_graveyard(geometry_file)
+   except Exception:
+       pass
 
    # Convert the geometry file and data file to the proper format.
    geometry_file = py_mb_convert(geometry_file, ".stl")

--- a/PythonTool/DataLoading.py
+++ b/PythonTool/DataLoading.py
@@ -171,6 +171,7 @@ def data_loading(geometry_file, data_file, images, session_file):
    try:
        geometry_file = remove_graveyard(geometry_file)
    except Exception:
+       print("WARNING: The geometry file did not contain a graveyard.")
        pass
 
    # Convert the geometry file and data file to the proper format.

--- a/PythonTool/GraveIdentifyAndRemove.py
+++ b/PythonTool/GraveIdentifyAndRemove.py
@@ -6,8 +6,9 @@ from pymoab.types import MBENTITYSET
 
 def parse_arguments():
     """
-    Parse the argument list and return an input file location and an optional
-    output file name.
+    Parse the argument list and return an input file location, an optional
+    output file name, and indication of whether or not to print the entity handle
+    of the EntitySet with a "graveyard" Name tag value.
 
     Input:
     ______
@@ -16,7 +17,8 @@ def parse_arguments():
     Returns:
     ________
        args: Namespace
-           User supplied input file location and optional output file name.
+           User supplied input file location, optional output file name, and
+           indication of whether or not to print the graveyard entity handle.
     """
 
     parser = argparse.ArgumentParser(description="Remove graveyard from an h5m data file.")
@@ -28,6 +30,10 @@ def parse_arguments():
     parser.add_argument("-o", "--outputfile",
                         type=str,
                         help="Provide a name and extension for the output file."
+                        )
+    parser.add_argument("-p", "--printhandle",
+                        action="store_true",
+                        help="Indicates whether or not to print the graveyard entity handle."
                         )
 
     args = parser.parse_args()
@@ -66,7 +72,7 @@ def get_sets_by_category(mb_core, category_name):
     return group_categories
 
 
-def remove_graveyard(input_file, output_file = None):
+def remove_graveyard(input_file, output_file = None, print_handle = None):
     """
     Remove the graveyard volume from the data file and write the result
     out to disk with a default input name or specified output name.
@@ -75,12 +81,17 @@ def remove_graveyard(input_file, output_file = None):
     write the file. If they haven't, append "_no_grave" onto the name of the
     input file and add the .h5m extension.
 
+    If the user has indicated to, print the entity handle of the EntitySet with
+    the ""graveyard" Name tag value.
+
     Input:
     ______
        input_file: str
            User supplied data file location.
        output_file: str
            Optional user supplied output file name and extension.
+       print_handle: boolean
+           Indicates whether or not to print the graveyard entity handle.
 
     Returns:
     ________
@@ -89,7 +100,7 @@ def remove_graveyard(input_file, output_file = None):
 
     Raises:
     _______
-       Exception: If no graveyard EntitySet is found.
+       LookupError: If no graveyard EntitySet is found.
     """
 
     mb = core.Core()
@@ -118,8 +129,10 @@ def remove_graveyard(input_file, output_file = None):
     if len(graveyard_sets) < 1:
         raise LookupError("WARNING: The geometry file did not contain a graveyard.")
 
-    # Print the entity handle of the EntitySet with the "graveyard" Name tag value.
-    print(graveyard_sets)
+    # If the user would like, print the graveyard entity handle.
+    if print_handle:
+        print("The entity handle(s) of the graveyard EntitySet(s): ")
+        print(graveyard_sets)
 
     # Remove the graveyard EntitySet from the data.
     groups_to_write = [group_set for group_set in group_categories
@@ -150,7 +163,7 @@ def main():
 
     # Remove the graveyard from the data file.
     try:
-        output_file = remove_graveyard(args.h5mfile, args.outputfile)
+        output_file = remove_graveyard(args.h5mfile, args.outputfile, args.printhandle)
     except LookupError, e:
         print(e.message)
 

--- a/PythonTool/GraveIdentifyAndRemove.py
+++ b/PythonTool/GraveIdentifyAndRemove.py
@@ -116,7 +116,7 @@ def remove_graveyard(input_file, output_file = None):
 
     # Raise an exception if there was no graveyard EntitySet found.
     if len(graveyard_sets) < 1:
-        raise Exception()
+        raise LookupError("WARNING: The geometry file did not contain a graveyard.")
 
     # Print the entity handle of the EntitySet with the "graveyard" Name tag value.
     print(graveyard_sets)
@@ -151,8 +151,8 @@ def main():
     # Remove the graveyard from the data file.
     try:
         output_file = remove_graveyard(args.h5mfile, args.outputfile)
-    except Exception:
-        print("WARNING: This file did not contain a graveyard. No new file was written.")
+    except LookupError, e:
+        print(e.message)
 
 
 if __name__ == "__main__":

--- a/PythonTool/GraveIdentifyAndRemove.py
+++ b/PythonTool/GraveIdentifyAndRemove.py
@@ -8,7 +8,7 @@ def parse_arguments():
     """
     Parse the argument list and return an input file location, an optional
     output file name, and indication of whether or not to print the entity handle
-    of the EntitySet with a "graveyard" Name tag value.
+    of the EntitySet with the "graveyard" Name tag value.
 
     Input:
     ______
@@ -82,7 +82,7 @@ def remove_graveyard(input_file, output_file = None, print_handle = None):
     input file and add the .h5m extension.
 
     If the user has indicated to, print the entity handle of the EntitySet with
-    the ""graveyard" Name tag value.
+    the "graveyard" Name tag value.
 
     Input:
     ______

--- a/PythonTool/GraveIdentifyAndRemove.py
+++ b/PythonTool/GraveIdentifyAndRemove.py
@@ -1,12 +1,12 @@
 import argparse
 import numpy as np
-from pymoab import core, types, tag
+from pymoab import core, tag, types
 from pymoab.types import MBENTITYSET
 
 
 def parse_arguments():
     """
-    Parse the argument list and return an input file location and optional
+    Parse the argument list and return an input file location and an optional
     output file name.
 
     Input:
@@ -48,7 +48,7 @@ def get_sets_by_category(mb_core, category_name):
 
     Returns:
     ________
-       entity_set_ids: list
+       entity_set_ids: List
            The ID list of the EntitySets specific to the chosen Category tag value.
     """
 
@@ -86,6 +86,10 @@ def remove_graveyard(input_file, output_file = None):
     ________
        output_file: str
            The name of the file written to the disk.
+
+    Raises:
+    _______
+       Exception: If no graveyard EntitySet is found.
     """
 
     mb = core.Core()
@@ -110,12 +114,11 @@ def remove_graveyard(input_file, output_file = None):
     if len(graveyard_sets) > 1:
         print("WARNING: More than one graveyard set found.")
 
-    # Warn the user if the file they provided did not contain a graveyard.
+    # Raise an exception if there was no graveyard EntitySet found.
     if len(graveyard_sets) < 1:
-        print("WARNING: This file did not contain a graveyard.")
-        exit()
+        raise Exception()
 
-    # Print the entity handle of the EntitySet(s) with the "graveyard" Name tag value.
+    # Print the entity handle of the EntitySet with the "graveyard" Name tag value.
     print(graveyard_sets)
 
     # Remove the graveyard EntitySet from the data.
@@ -146,7 +149,10 @@ def main():
     args = parse_arguments()
 
     # Remove the graveyard from the data file.
-    output_file = remove_graveyard(args.h5mfile, args.outputfile)
+    try:
+        output_file = remove_graveyard(args.h5mfile, args.outputfile)
+    except Exception:
+        print("WARNING: This file did not contain a graveyard. No new file was written.")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Raise exception in `remove_graveyard` of `GraveIdentifyAndRemove.py` if no graveyard EntitySet is found. (Specified in #19).