### PR TITLE
User can specify MB element for tag search

### DIFF
--- a/PythonTool/TagExpansion.py
+++ b/PythonTool/TagExpansion.py
@@ -4,6 +4,24 @@ import os
 from pymoab import core, tag, types
 
 
+# Create a dictionary with the MB element types and their integer values.
+elements = {
+    types.MBVERTEX : "vertex",
+    types.MBEDGE : "edge",
+    types.MBTRI : "tri",
+    types.MBQUAD : "quad",
+    types.MBPOLYGON : "polygon",
+    types.MBTET : "tet",
+    types.MBPYRAMID : "pyramid",
+    types.MBPRISM : "prism",
+    types.MBKNIFE : "knife",
+    types.MBHEX : "hex",
+    types.MBPOLYHEDRON : "polyhedron",
+    types.MBENTITYSET : "entityset",
+    types.MAXTYPE : "maxtype"
+}
+
+
 def parse_arguments():
     """
     Parse the argument list and return a mesh file location, optional main
@@ -33,6 +51,7 @@ def parse_arguments():
     parser.add_argument("-e", "--element",
                         type=str,
                         default="hex",
+                        choices=elements.values(),
                         help="""Provide a type of MB element other than hex. Valid
                              element types include vertex, edge, tri, quad, polygon,
                              tet, pyramid, prism, knife, polyhedron, entityset,
@@ -180,25 +199,12 @@ def expand_vector_tags(mesh_file, element_type, main_dir_name = None):
        LookupError: If the file does not contain any vector tags.
     """
 
-    # Create a dictionary with the MB element types.
-    elements = {
-        "vertex" : types.MBVERTEX, "edge" : types.MBEDGE, "tri" : types.MBTRI,
-        "quad" : types.MBQUAD, "polygon" : types.MBPOLYGON, "tet" : types.MBTET,
-        "pyramid" : types.MBPYRAMID, "prism" : types.MBPRISM, "knife" : types.MBKNIFE,
-        "hex" : types.MBHEX, "polyhedron" : types.MBPOLYHEDRON, "maxtype" : types.MBMAXTYPE,
-        "entityset" : types.MBENTITYSET
-        }
-
     # Load the mesh file to create a reference mesh.
     mb_ref = core.Core()
     mb_ref.load_file(mesh_file)
 
     # Ensure the MB element type is valid.
     mb_type = elements.get(element_type.lower())
-
-    if mb_type is None:
-        print("WARNING: Please choose a valid MB element type.")
-        exit()
 
     # Retrieve the lists of scalar and vector tags on the reference mesh.
     try:

--- a/PythonTool/TagExpansion.py
+++ b/PythonTool/TagExpansion.py
@@ -21,6 +21,7 @@ elements = {
     types.MAXTYPE : "maxtype"
 }
 
+reverse_elements = { v: k for k, v in elements.items() }
 
 def parse_arguments():
     """
@@ -204,7 +205,7 @@ def expand_vector_tags(mesh_file, element_type, main_dir_name = None):
     mb_ref.load_file(mesh_file)
 
     # Ensure the MB element type is valid.
-    mb_type = elements[element_type.lower()]
+    mb_type = reverse_elements[element_type.lower()]
 
     # Retrieve the lists of scalar and vector tags on the reference mesh.
     try:

--- a/PythonTool/TagExpansion.py
+++ b/PythonTool/TagExpansion.py
@@ -7,8 +7,7 @@ from pymoab import core, tag, types
 def parse_arguments():
     """
     Parse the argument list and return a mesh file location, optional main
-    directory name, and optional MB element type if the mesh file does not contain
-    any hex elements.
+    directory name, and optional MB element type.
 
     Input:
     ______
@@ -131,8 +130,8 @@ def create_database(mesh_file, mb_ref, mb_exp, elements, scal_tags, vec_tag, dir
     name = vec_tag.get_name()
 
     # Create a directory to store the vector tag expansion files.
-    vec_dir_name = name + "_database"
-    os.mkdir(dir_name + "/" + vec_dir_name)
+    vec_dir_name = dir_name + "/" + name + "_database"
+    os.mkdir(vec_dir_name)
 
     """
     For the vector tag on each element, retrieve the scalar value at a specific
@@ -151,7 +150,7 @@ def create_database(mesh_file, mb_ref, mb_exp, elements, scal_tags, vec_tag, dir
         mb_ref.tag_set_data(scalar_tag, elements, scalar_data)
 
         # Write the mesh file with the new scalar tag.
-        file_location = os.getcwd() + "/" + dir_name + "/" + vec_dir_name + "/" + name + str(index) + ".vtk"
+        file_location = os.getcwd() + "/" + vec_dir_name + "/" + name + str(index) + ".vtk"
         mb_ref.write_file(file_location)
         index += 1
 
@@ -160,7 +159,7 @@ def create_database(mesh_file, mb_ref, mb_exp, elements, scal_tags, vec_tag, dir
 
 def expand_vector_tags(mesh_file, main_dir_name = None, element_type = None):
     """
-    Load the mesh file and extract the lists of scalar and vector tags, then
+    Load the mesh file, extract the lists of scalar and vector tags, and
     expand each vector tag.
 
     Input:
@@ -266,11 +265,9 @@ def expand_vector_tags(mesh_file, main_dir_name = None, element_type = None):
         dict_number += 1
     os.mkdir(dir_name)
 
-    """
     # Expand each vector tag present in the mesh.
     for tag in vec_tags_exp:
         create_database(mesh_file, mb_ref, mb_exp, elements_ref, scal_tags_ref, tag, dir_name)
-    """
 
 
 def main():

--- a/PythonTool/TagExpansion.py
+++ b/PythonTool/TagExpansion.py
@@ -56,8 +56,7 @@ def get_tag_lists(mb, element_type, element_id):
        element_type: str
            The type of MOAB element from which to extract the tag list.
        element_id: int
-           The type of MOAB element from which to extract the tag list,
-           represented by an integer.
+           The type of MOAB element from which to extract the tag list.
 
     Returns:
     ________
@@ -181,11 +180,13 @@ def expand_vector_tags(mesh_file, element_type, main_dir_name = None):
        LookupError: If the file does not contain any vector tags.
     """
 
-    # Create a dictionary with the MB element types and their integer values.
+    # Create a dictionary with the MB element types.
     elements = {
-        "vertex" : 0, "edge" : 1, "tri" : 2, "quad" : 3, "polygon" : 4,
-        "tet" : 5, "pyramid" : 6, "prism" : 7, "knife" : 8, "hex" : 9,
-        "polyhedron" : 10, "entityset" : 11, "maxtype" : 12
+        "vertex" : types.MBVERTEX, "edge" : types.MBEDGE, "tri" : types.MBTRI,
+        "quad" : types.MBQUAD, "polygon" : types.MBPOLYGON, "tet" : types.MBTET,
+        "pyramid" : types.MBPYRAMID, "prism" : types.MBPRISM, "knife" : types.MBKNIFE,
+        "hex" : types.MBHEX, "polyhedron" : types.MBPOLYHEDRON, "maxtype" : types.MBMAXTYPE,
+        "entityset" : types.MBENTITYSET
         }
 
     # Load the mesh file to create a reference mesh.
@@ -193,15 +194,15 @@ def expand_vector_tags(mesh_file, element_type, main_dir_name = None):
     mb_ref.load_file(mesh_file)
 
     # Ensure the MB element type is valid.
-    type_int = elements.get(element_type.lower())
+    mb_type = elements.get(element_type.lower())
 
-    if type_int is None:
+    if mb_type is None:
         print("WARNING: Please choose a valid MB element type.")
         exit()
 
     # Retrieve the lists of scalar and vector tags on the reference mesh.
     try:
-        elements_ref, scal_tags_ref, vec_tags_ref = get_tag_lists(mb_ref, element_type, type_int)
+        elements_ref, scal_tags_ref, vec_tags_ref = get_tag_lists(mb_ref, element_type, mb_type)
     except LookupError as e:
         print(str(e))
         exit()
@@ -220,7 +221,7 @@ def expand_vector_tags(mesh_file, element_type, main_dir_name = None):
 
     # Retrieve the lists of scalar and vector tags on the mesh.
     try:
-        elements_exp, scal_tags_exp, vec_tags_exp = get_tag_lists(mb_exp, element_type, type_int)
+        elements_exp, scal_tags_exp, vec_tags_exp = get_tag_lists(mb_exp, element_type, mb_type)
     except LookupError as e:
         print(str(e))
         exit()

--- a/PythonTool/TagExpansion.py
+++ b/PythonTool/TagExpansion.py
@@ -204,7 +204,7 @@ def expand_vector_tags(mesh_file, element_type, main_dir_name = None):
     mb_ref.load_file(mesh_file)
 
     # Ensure the MB element type is valid.
-    mb_type = elements.get(element_type.lower())
+    mb_type = elements[element_type.lower()]
 
     # Retrieve the lists of scalar and vector tags on the reference mesh.
     try:

--- a/PythonTool/TagExpansion.py
+++ b/PythonTool/TagExpansion.py
@@ -213,7 +213,7 @@ def expand_vector_tags(mesh_file, main_dir_name = None, element_type = None):
 
     # Warn the user if the mesh file does not contain at least one vector tag.
     if len(vec_tags_ref) < 1:
-        raise LookupError("WARNING: This mesh file did not contain any vector tags.")
+        raise LookupError("WARNING: This mesh file did not contain any vector tags on " + element_type + " elements.")
 
     # Delete each vector tag from the reference mesh.
     for tag in vec_tags_ref:

--- a/PythonTool/TagExpansion.py
+++ b/PythonTool/TagExpansion.py
@@ -80,7 +80,7 @@ def get_tag_lists(mb, element_type, element_id):
 
     # Warn the user if there are none of the specified mesh elements.
     if len(element_list) == 0:
-        raise LookupError("WARNING: No " + element_type + " elements were found in the mesh.")
+        raise LookupError("WARNING: No {} elements were found in the mesh.".format(element_type))
 
     tag_list = mb.tag_get_tags_on_entity(element_list[0])
 
@@ -216,7 +216,7 @@ def expand_vector_tags(mesh_file, main_dir_name = None, element_type = None):
 
     # Warn the user if the mesh file does not contain at least one vector tag.
     if len(vec_tags_ref) < 1:
-        raise LookupError("WARNING: This mesh file did not contain any vector tags on " + element_type + " elements.")
+        raise LookupError("WARNING: This mesh file did not contain any vector tags on {} elements.".format(element_type))
 
     # Delete each vector tag from the reference mesh.
     for tag in vec_tags_ref:
@@ -266,9 +266,11 @@ def expand_vector_tags(mesh_file, main_dir_name = None, element_type = None):
         dict_number += 1
     os.mkdir(dir_name)
 
+    """
     # Expand each vector tag present in the mesh.
     for tag in vec_tags_exp:
         create_database(mesh_file, mb_ref, mb_exp, elements_ref, scal_tags_ref, tag, dir_name)
+    """
 
 
 def main():

--- a/PythonTool/TagExpansion.py
+++ b/PythonTool/TagExpansion.py
@@ -51,7 +51,7 @@ def parse_arguments():
     parser.add_argument("-e", "--element",
                         type=str,
                         default="hex",
-                        choices=elements.values(),
+                        choices=list(elements.values()),  # not sure if the cast to list() is necessary
                         help="""Provide a type of MB element other than hex. Valid
                              element types include vertex, edge, tri, quad, polygon,
                              tet, pyramid, prism, knife, polyhedron, entityset,

--- a/PythonTool/TagExpansion.py
+++ b/PythonTool/TagExpansion.py
@@ -74,7 +74,7 @@ def get_tag_lists(mb, element_type, element_id):
        LookupError: If no element of the user specified type is found.
     """
 
-    # Retrieve an arbitrary element of the specified type in the mesh and extract the tag list.
+    # Retrieve arbitrary element of specified type in the mesh and extract the tag list.
     root = mb.get_root_set()
     element_list = mb.get_entities_by_type(root, element_id)
 
@@ -249,7 +249,6 @@ def main():
 
     args = parse_arguments()
 
-    # Expand the vector tags from the mesh file.
     try:
         expand_vector_tags(args.meshfile, args.element, args.dirname)
     except LookupError as e:

--- a/PythonTool/TagExpansion.py
+++ b/PythonTool/TagExpansion.py
@@ -33,7 +33,10 @@ def parse_arguments():
                         )
     parser.add_argument("-e", "--element",
                         type=str,
-                        help="Provide a type of MB element other than hex."
+                        help="""Provide a type of MB element other than hex. Valid
+                             element types include vertex, edge, tri, quad, polygon,
+                             tet, pyramid, prism, knife, polyhedron, entityset,
+                             and maxtype."""
                         )
 
     args = parser.parse_args()

--- a/PythonTool/TagExpansion.py
+++ b/PythonTool/TagExpansion.py
@@ -6,22 +6,21 @@ from pymoab import core, tag, types
 
 # Create a dictionary with the MB element types and their integer values.
 elements = {
-    types.MBVERTEX : "vertex",
-    types.MBEDGE : "edge",
-    types.MBTRI : "tri",
-    types.MBQUAD : "quad",
-    types.MBPOLYGON : "polygon",
-    types.MBTET : "tet",
-    types.MBPYRAMID : "pyramid",
-    types.MBPRISM : "prism",
-    types.MBKNIFE : "knife",
-    types.MBHEX : "hex",
-    types.MBPOLYHEDRON : "polyhedron",
-    types.MBENTITYSET : "entityset",
-    types.MAXTYPE : "maxtype"
+    "vertex" : types.MBVERTEX,
+    "edge" : types.MBEDGE,
+    "tri" : types.MBTRI,
+    "quad" : types.MBQUAD,
+    "polygon" : types.MBPOLYGON,
+    "tet" : types.MBTET,
+    "pyramid" : types.MBPYRAMID,
+    "prism" : types.MBPRISM,
+    "knife" : types.MBKNIFE,
+    "hex" : types.MBHEX,
+    "polyhedron" : types.MBPOLYHEDRON,
+    "entityset" : types.MBENTITYSET,
+    "maxtype" : types.MBMAXTYPE
 }
 
-reverse_elements = { v: k for k, v in elements.items() }
 
 def parse_arguments():
     """
@@ -52,11 +51,8 @@ def parse_arguments():
     parser.add_argument("-e", "--element",
                         type=str,
                         default="hex",
-                        choices=list(elements.values()),  # not sure if the cast to list() is necessary
-                        help="""Provide a type of MB element other than hex. Valid
-                             element types include vertex, edge, tri, quad, polygon,
-                             tet, pyramid, prism, knife, polyhedron, entityset,
-                             and maxtype."""
+                        choices=elements.keys(),
+                        help="Provide a type of MB element other than hex."
                         )
 
     args = parser.parse_args()
@@ -205,14 +201,10 @@ def expand_vector_tags(mesh_file, element_type, main_dir_name = None):
     mb_ref.load_file(mesh_file)
 
     # Ensure the MB element type is valid.
-    mb_type = reverse_elements[element_type.lower()]
+    mb_type = elements[element_type.lower()]
 
     # Retrieve the lists of scalar and vector tags on the reference mesh.
-    try:
-        elements_ref, scal_tags_ref, vec_tags_ref = get_tag_lists(mb_ref, element_type, mb_type)
-    except LookupError as e:
-        print(str(e))
-        exit()
+    elements_ref, scal_tags_ref, vec_tags_ref = get_tag_lists(mb_ref, element_type, mb_type)
 
     # Warn the user if the mesh file does not contain at least one vector tag.
     if len(vec_tags_ref) < 1:
@@ -227,11 +219,7 @@ def expand_vector_tags(mesh_file, element_type, main_dir_name = None):
     mb_exp.load_file(mesh_file)
 
     # Retrieve the lists of scalar and vector tags on the mesh.
-    try:
-        elements_exp, scal_tags_exp, vec_tags_exp = get_tag_lists(mb_exp, element_type, mb_type)
-    except LookupError as e:
-        print(str(e))
-        exit()
+    elements_exp, scal_tags_exp, vec_tags_exp = get_tag_lists(mb_exp, element_type, mb_type)
 
     # Create a directory for the vector tag expansion files.
     if main_dir_name is None:

--- a/PythonTool/TagExpansion.py
+++ b/PythonTool/TagExpansion.py
@@ -49,10 +49,10 @@ def parse_arguments():
                         help="Provide a name for the main directory."
                         )
     parser.add_argument("-e", "--element",
-                        type=str,
+                        type=str.lower,
                         default="hex",
                         choices=elements.keys(),
-                        help="Provide a type of MB element other than hex."
+                        help="Provide the type of MOAB element on which to expand tags."
                         )
 
     args = parser.parse_args()
@@ -70,9 +70,11 @@ def get_tag_lists(mb, element_type, element_id):
        mb: Core
            A PyMOAB core instance with a loaded data file.
        element_type: str
-           The type of MOAB element from which to extract the tag list.
+           The type of MOAB element from which to extract the tag list
+           represented by a string.
        element_id: int
-           The type of MOAB element from which to extract the tag list.
+           The type of MOAB element from which to extract the tag list
+           represented by an integer.
 
     Returns:
     ________
@@ -201,7 +203,7 @@ def expand_vector_tags(mesh_file, element_type, main_dir_name = None):
     mb_ref.load_file(mesh_file)
 
     # Ensure the MB element type is valid.
-    mb_type = elements[element_type.lower()]
+    mb_type = elements[element_type]
 
     # Retrieve the lists of scalar and vector tags on the reference mesh.
     elements_ref, scal_tags_ref, vec_tags_ref = get_tag_lists(mb_ref, element_type, mb_type)

--- a/PythonTool/TagExpansion.py
+++ b/PythonTool/TagExpansion.py
@@ -263,11 +263,9 @@ def expand_vector_tags(mesh_file, main_dir_name = None, element_type = None):
         dict_number += 1
     os.mkdir(dir_name)
 
-    """
     # Expand each vector tag present in the mesh.
     for tag in vec_tags_exp:
         create_database(mesh_file, mb_ref, mb_exp, hexes_ref, scal_tags_ref, tag, dir_name)
-    """
 
 
 def main():


### PR DESCRIPTION
Updated `TagExpansion.py` so the user can specify which MB element is used to gather vector tags from the mesh. If no element is specified, MBHEX is the default. (Specified in #35) 

NOTE: There is code duplication in `expand_vector_tags` when extracting the list of elements, scalar tags, and vector tags from the mesh because this is done both for the reference mesh and the expansion mesh. This will be remedied in the next PR when the need for loading two mesh instances is eliminated.